### PR TITLE
[FEAT] 각 화면 연결 및 메인 화면 분기 구현

### DIFF
--- a/Dear/Dear/Controllers/HospitalViewController.swift
+++ b/Dear/Dear/Controllers/HospitalViewController.swift
@@ -44,13 +44,16 @@ class HospitalViewController: UIViewController {
     @objc private func pushToNext() {
         let hospitalName = hospitalTextField.text
         
-        guard hospitalName == "병원" else { return }
+        guard hospitalName != "병원" else { return }
         
         UserDefaults.standard.set(hospitalName, forKey: "hospital")
-            
+        
         switch UserDefaults.standard.string(forKey: "user") {
         case "nurse":
-            print("nurse")
+            let storyboard = UIStoryboard(name: "NurseMain", bundle: nil)
+            let nurseMainViewController = storyboard.instantiateViewController(withIdentifier: "NurseMain")
+            
+            navigationController?.pushViewController(nurseMainViewController, animated: true)
         case "patient":
             print("patient")
         default:

--- a/Dear/Dear/Controllers/HospitalViewController.swift
+++ b/Dear/Dear/Controllers/HospitalViewController.swift
@@ -55,7 +55,10 @@ class HospitalViewController: UIViewController {
             
             navigationController?.pushViewController(nurseMainViewController, animated: true)
         case "patient":
-            print("patient")
+            let storyboard = UIStoryboard(name: "PatientPillBagView", bundle: nil)
+            let patientMainViewController = storyboard.instantiateViewController(withIdentifier: "PatientPillBagView")
+            
+            navigationController?.pushViewController(patientMainViewController, animated: true)
         default:
             fatalError("Error: User isn't Selected")
         }

--- a/Dear/Dear/SceneDelegate.swift
+++ b/Dear/Dear/SceneDelegate.swift
@@ -20,10 +20,24 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: UIScreen.main.bounds)
         
-        let storyboard = UIStoryboard(name: "SelectUser", bundle: nil)
-        let navigationController = storyboard.instantiateViewController(withIdentifier: "UINavigationController")
+        switch UserDefaults.standard.string(forKey: "user") {
+        case "nurse":
+            let stroyboard = UIStoryboard(name: "NurseMain", bundle: nil)
+            let nurseMainViewController = stroyboard.instantiateViewController(withIdentifier: "NurseMain")
+            
+            window?.rootViewController = nurseMainViewController
+        case "patient":
+            let stroyboard = UIStoryboard(name: "PatientPillBagView", bundle: nil)
+            let patientMainViewController = stroyboard.instantiateViewController(withIdentifier: "PatientPillBagView")
+            
+            window?.rootViewController = patientMainViewController
+        default:
+            let storyboard = UIStoryboard(name: "SelectUser", bundle: nil)
+            let navigationController = storyboard.instantiateViewController(withIdentifier: "UINavigationController")
+            
+            window?.rootViewController = navigationController
+        }
         
-        window?.rootViewController = navigationController
         window?.windowScene = scene
         window?.makeKeyAndVisible()
     }

--- a/Dear/Dear/Views/NurseMain.storyboard
+++ b/Dear/Dear/Views/NurseMain.storyboard
@@ -12,7 +12,7 @@
         <!--Nurse Main Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController id="Y6W-OH-hqX" customClass="NurseMainController" customModule="Dear" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NurseMain" id="Y6W-OH-hqX" customClass="NurseMainController" customModule="Dear" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Dear/Dear/Views/NurseMain.storyboard
+++ b/Dear/Dear/Views/NurseMain.storyboard
@@ -505,10 +505,10 @@
             </objects>
             <point key="canvasLocation" x="970.76923076923072" y="75.355450236966817"/>
         </scene>
-        <!--NurseMainView-->
+        <!--NursePillBagViewController-->
         <scene sceneID="8VQ-G6-bpG">
             <objects>
-                <viewControllerPlaceholder storyboardName="NurseMainView" referencedIdentifier="NurseMainView" id="ozc-Cb-DRK" sceneMemberID="viewController">
+                <viewControllerPlaceholder storyboardName="NursePillBagView" referencedIdentifier="NursePillBagViewController" id="ozc-Cb-DRK" sceneMemberID="viewController">
                     <navigationItem key="navigationItem" id="OTp-ze-0mf"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="AvI-Br-90c" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Dear/Dear/Views/NursePillBagView.storyboard
+++ b/Dear/Dear/Views/NursePillBagView.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="NDb-Lh-c2G">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="7Ra-cC-eUo">
-                                <rect key="frame" x="0.0" y="124" width="414" height="612"/>
+                                <rect key="frame" x="0.0" y="80" width="414" height="656"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="1" reuseIdentifier="LetterCell" rowHeight="277" id="WIT-hN-TRG" customClass="NursePillBagViewCell" customModule="Dear" customModuleProvider="target">
@@ -174,7 +174,7 @@
                                 </prototypes>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zYT-zn-zWx">
-                                <rect key="frame" x="0.0" y="44" width="414" height="80"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="80"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J0X-dI-0EK" customClass="UIViewExtension" customModule="Dear" customModuleProvider="target">
                                         <rect key="frame" x="20" y="14" width="98" height="46"/>
@@ -230,22 +230,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1.4492753623188408" y="490.76086956521743"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="8pF-yy-F4q">
-            <objects>
-                <navigationController id="NDb-Lh-c2G" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="xdI-yD-NE4">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="Y6W-OH-hqX" kind="relationship" relationship="rootViewController" id="39b-yJ-xmn"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="ogg-d3-zwo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-765" y="491"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
## 세부 사항
- 처음 세팅 후 각 사용자에 맞게 홈 화면 다르도록 SceneDelegate.swift 설정
- 처음 설정 시에도 적절한 홈 화면으로 이동하도록 구현

## 기타 질문 및 특이 사항
- 처음 세팅할 때는 네비게이션으로 잘 가는데, 메인을 직접 연결하면 모달로 바뀌는 버그 발견(수정 예정)
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
